### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @sapcc/network-api-contributors @sapcc/cc_github_managers_approval
+/.github/CODEOWNERS @sapcc/cc_github_managers_approval

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ subunit.log
 !/.coveragerc
 !/.gitignore
 !/.gitreview
+!/.github
 !/.mailmap
 !/.pylintrc
 !/.stestr.conf


### PR DESCRIPTION
Based on our engineering policy and PCI DSS 4.0 requirements, all repositories that modify production infrastructure must enforce a two-person approval process. This patch adds a CODEOWNERS file to to define the approvers for the repository.